### PR TITLE
Display image instead of link

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,9 @@ function getSusiAnswer(clientMsg){
 			else
 			{
 				ans = action.expression;
+				if(ans.endsWith(".png") || ans.endsWith(".jpg") || ans.endsWith(".jpeg") || ans.endsWith(".gif") ){
+					ans = "![image](" + ans + ")";
+				}
 				sendAnswer(ans);
 			}
 		});


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #39 

#### Changes proposed in this pull request:

- detect when the server sends an image's link. Replace that link with the github markdown to display an image.

**Screenshot for the change:**
Before:
![image](https://user-images.githubusercontent.com/17807257/41577238-559b759c-73a9-11e8-88cb-6167e0c85d3d.png)
After:
![image](https://user-images.githubusercontent.com/17807257/41577248-6044112a-73a9-11e8-817a-88f30388d606.png)

